### PR TITLE
Improve Sentry configuration and UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel

--- a/README.md
+++ b/README.md
@@ -1,36 +1,43 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# SSR Example with Sentry
 
-## Getting Started
+This example demonstrates how to use Sentry with a Next.js project that includes server side rendering and profiling.
 
-First, run the development server:
+## Prerequisites
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
+- Node.js 18 or later
+- npm
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Setup
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+1. **Install dependencies**
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+   ```bash
+   npm install
+   ```
 
-## Learn More
+2. **Create a `.env` file** in the project root with your Sentry credentials:
 
-To learn more about Next.js, take a look at the following resources:
+   ```bash
+   NEXT_PUBLIC_SENTRY_DSN=<your_dsn>
+   SENTRY_DSN=<your_dsn>
+   SENTRY_AUTH_TOKEN=<your_auth_token>
+   SENTRY_ORG=<your_organization_slug>
+   SENTRY_PROJECT=<your_project_name>
+   ```
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+   The DSN values configure the client and server SDKs. The auth token, organization slug, and project name are used by the Sentry Webpack plugin when building the application.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+3. **Run the development server**
 
-## Deploy on Vercel
+   ```bash
+   npm run dev
+   ```
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+   The application will be available at [http://localhost:3000](http://localhost:3000).
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+## Features
+
+- **Server-side rendering example** available at `/ssr-example`.
+- **Client and server spans** contain a custom `operation` tag to distinguish where they were created.
+- **Stylistic front‑end** inspired by [sentry.io](https://sentry.io).
+

--- a/pages/ssr-example.js
+++ b/pages/ssr-example.js
@@ -6,6 +6,7 @@ export async function getServerSideProps() {
     });
 
     const fetchSpan = Sentry.startSpan({ name: 'fetch-data' });
+    fetchSpan.setAttribute('operation', 'server-side');
     try {
         // Simulate fetching data from an API or database
         const data = { message: 'Hello from the server side!' };

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -2,7 +2,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-  dsn: 'https://4caf53527042b95271893cfa197eeab6@o4504052292517888.ingest.us.sentry.io/4507986010898432',
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   // Profiling is only enabled on the server for this example
   tracesSampleRate: 1.0,
   profilesSampleRate: 1.0,

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/nextjs';
 import { ProfilingIntegration } from '@sentry/profiling-node';
 
 Sentry.init({
-  dsn: 'https://4caf53527042b95271893cfa197eeab6@o4504052292517888.ingest.us.sentry.io/4507986010898432',
+  dsn: process.env.SENTRY_DSN,
   integrations: [new ProfilingIntegration()],
   tracesSampleRate: 1.0,
   profilesSampleRate: 1.0,

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -1,165 +1,32 @@
 .page {
-  --gray-rgb: 0, 0, 0;
-  --gray-alpha-200: rgba(var(--gray-rgb), 0.08);
-  --gray-alpha-100: rgba(var(--gray-rgb), 0.05);
-
-  --button-primary-hover: #383838;
-  --button-secondary-hover: #f2f2f2;
-
-  display: grid;
-  grid-template-rows: 20px 1fr 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   align-items: center;
-  justify-items: center;
-  min-height: 100svh;
-  padding: 80px;
-  gap: 64px;
+  min-height: 100vh;
+  background: linear-gradient(120deg, #6c5fc7, #482682);
+  color: #ffffff;
+  text-align: center;
   font-family: var(--font-geist-sans);
-}
-
-@media (prefers-color-scheme: dark) {
-  .page {
-    --gray-rgb: 255, 255, 255;
-    --gray-alpha-200: rgba(var(--gray-rgb), 0.145);
-    --gray-alpha-100: rgba(var(--gray-rgb), 0.06);
-
-    --button-primary-hover: #ccc;
-    --button-secondary-hover: #1a1a1a;
-  }
+  padding: 2rem;
 }
 
 .main {
   display: flex;
   flex-direction: column;
-  gap: 32px;
-  grid-row-start: 2;
+  gap: 1.5rem;
 }
 
-.main ol {
+.title {
+  font-size: 3rem;
+  font-weight: 700;
+}
+
+.tagline {
+  font-size: 1.25rem;
+}
+
+.message {
   font-family: var(--font-geist-mono);
-  padding-left: 0;
-  margin: 0;
-  font-size: 14px;
-  line-height: 24px;
-  letter-spacing: -0.01em;
-  list-style-position: inside;
-}
-
-.main li:not(:last-of-type) {
-  margin-bottom: 8px;
-}
-
-.main code {
-  font-family: inherit;
-  background: var(--gray-alpha-100);
-  padding: 2px 4px;
-  border-radius: 4px;
-  font-weight: 600;
-}
-
-.ctas {
-  display: flex;
-  gap: 16px;
-}
-
-.ctas a {
-  appearance: none;
-  border-radius: 128px;
-  height: 48px;
-  padding: 0 20px;
-  border: none;
-  border: 1px solid transparent;
-  transition: background 0.2s, color 0.2s, border-color 0.2s;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 16px;
-  line-height: 20px;
-  font-weight: 500;
-}
-
-a.primary {
-  background: var(--foreground);
-  color: var(--background);
-  gap: 8px;
-}
-
-a.secondary {
-  border-color: var(--gray-alpha-200);
-  min-width: 180px;
-}
-
-.footer {
-  grid-row-start: 3;
-  display: flex;
-  gap: 24px;
-}
-
-.footer a {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.footer img {
-  flex-shrink: 0;
-}
-
-/* Enable hover only on non-touch devices */
-@media (hover: hover) and (pointer: fine) {
-  a.primary:hover {
-    background: var(--button-primary-hover);
-    border-color: transparent;
-  }
-
-  a.secondary:hover {
-    background: var(--button-secondary-hover);
-    border-color: transparent;
-  }
-
-  .footer a:hover {
-    text-decoration: underline;
-    text-underline-offset: 4px;
-  }
-}
-
-@media (max-width: 600px) {
-  .page {
-    padding: 32px;
-    padding-bottom: 80px;
-  }
-
-  .main {
-    align-items: center;
-  }
-
-  .main ol {
-    text-align: center;
-  }
-
-  .ctas {
-    flex-direction: column;
-  }
-
-  .ctas a {
-    font-size: 14px;
-    height: 40px;
-    padding: 0 16px;
-  }
-
-  a.secondary {
-    min-width: auto;
-  }
-
-  .footer {
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .logo {
-    filter: invert();
-  }
+  font-size: 1.125rem;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,9 @@
-import Image from 'next/image';
 import styles from './page.module.css';
 import * as Sentry from '@sentry/nextjs';
 
 async function fetchData() {
-  return Sentry.startSpan({ name: 'fetchData' }, async () => {
+  return Sentry.startSpan({ name: 'fetchData' }, async (span) => {
+    span.setAttribute('operation', 'client-side');
     try {
       // Simulate data fetching
       const data = 'Hello, world!';
@@ -21,21 +21,9 @@ export default async function Home() {
   return (
     <div className={styles.page}>
       <main className={styles.main}>
-        <Image
-          className={styles.logo}
-          src="https://nextjs.org/icons/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol>
-          <li>
-            Get started by editing <code>src/app/page.tsx</code>.
-          </li>
-          <li>Save and see your changes instantly.</li>
-          <li>Data fetched from server: {data}</li>
-        </ol>
+        <h1 className={styles.title}>Sentry SSR Example</h1>
+        <p className={styles.tagline}>Monitor client and server operations with ease.</p>
+        <p className={styles.message}>Data fetched from server: {data}</p>
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- read Sentry credentials from `.env`
- mark every span with a new `operation` attribute
- restyle the example app inspired by Sentry.io
- document how to run the example and provide env vars
- ignore `.env` files

## Testing
- `npm run lint`
- `npm run build` *(fails to upload source maps due to missing auth token)*

------
https://chatgpt.com/codex/tasks/task_e_6857c46341d48326a3831803b9fd30dd